### PR TITLE
present.frag: Change border and highlight thresholds

### DIFF
--- a/shaders/present.frag
+++ b/shaders/present.frag
@@ -437,12 +437,12 @@ bool showPixelBorder(vec2 wh, vec2 offset, float imageScale)
     // We can't use the expressions above, they are not exactly the same, 
     // even though I don't know why.
     vec2 xy = floor(mod(wh - offset, imageScale));
-    return any(equal(xy, vec2(0.0))) && (imageScale > 5.0);
+    return any(equal(xy, vec2(0.0))) && (imageScale > 16.0);
 }
 
 bool showPixelBorderHighlight(vec2 wh, vec2 cursor, vec2 offset, float imageScale)
 {
-    if (!uEnablePixelHighlight || imageScale < 8.0) {
+    if (!uEnablePixelHighlight || imageScale < 24.0) {
         return false;
     }
 


### PR DESCRIPTION
* showPixelBorder: Start showing the border if imagescale > 16x

* showPixelBorderHighlight: Start showing the highlight square if imagescale > 24x

  Both of these changes seem more in line with the kind of real world thresholds used for comparing pixels visually without disruption of the pixel grid (which is only really necessary at high levels of zoom).