### PR TITLE
Flip order of first selected file and compared file

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -683,15 +683,26 @@ void App::processTextureUploadTasks()
         return;
     }
 
-    // When we finish importing images, we switch top image to the latest one.
     if (!isUndo && mTexturePool.hasNoPendingTasks()) {
+#if 0
+        // When we finish importing images, we switch top image to the latest one.
         mTopImageIndex = static_cast<int>(mImageList.size()) - 1;
         resetImageTransform(getTopImage()->size());
 
         if (mCmpImageIndex == -1 && mTopImageIndex >= 1) {
             mCmpImageIndex = 0;
         }
+#else
+        // When we finish importing images, we switch top image to the first one
+        // and compared image to the second one. This makes split and column
+        // comparisons follow the natural order of imported files.
+        mTopImageIndex = 0;
+        resetImageTransform(getTopImage()->size());
 
+        if (mCmpImageIndex == -1 && mImageList.size() > 1) {
+            mCmpImageIndex = 1;
+        }
+#endif
         mUpdateImageSelection = false;
     }
 }


### PR DESCRIPTION
* When specifying files via the command line, dragging files to the app, etc. it was found to be annoying that the last image was always the one on the "left" for purposes of compare/split view, particularly when dealing with before/after type images. It also doesn't seem particularly intuitive that when dragging multiple files to the app that the last one in the stack is the one opened first. Knowing that there might be a particular reason it was previously done this way (there is a comment saying so) the previous code was kept in but ifdef'ed out. Perhaps this could be made configurable if there's a good reason for it?