### PR TITLE
Allow pixel grid to be toggled on/off with keyboard

### DIFF
--- a/shaders/present.frag
+++ b/shaders/present.frag
@@ -25,6 +25,7 @@ uniform vec4    uCharUvXforms[11];
 uniform bool    uApplyToneMapping;
 uniform bool    uBlendWithImageAlpha;
 uniform bool    uEnablePixelHighlight;
+uniform bool    uEnablePixelBorder;
 
 in  vec2 vUV;
 out vec4 oColor;
@@ -430,6 +431,10 @@ float getRGBValueMatte(vec2 uv, vec3 color)
 
 bool showPixelBorder(vec2 wh, vec2 offset, float imageScale)
 {
+    if (!uEnablePixelBorder) {
+        return false;
+    }
+
     // vec2 xy = mod(wh - offset, imageScale);
     // return any(lessThan(xy, vec2(1.0))) && (imageScale > 5.0);
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -807,6 +807,7 @@ void App::run(CompositeFlags initFlags)
             mPresentShader.setUniform("uImageSize", Vec2f(0.0f));
         }
 
+        mPresentShader.setUniform("uEnablePixelBorder", mEnablePixelBorder);
         mPresentShader.setUniform("uEnablePixelHighlight", !mIsMovingSplitter && !mIsScalingImage);
         mPresentShader.setUniform("uCursorPos", Vec2f(io.MousePos.x, io.DisplaySize.y - io.MousePos.y) + Vec2f(0.5f));
         mPresentShader.setUniform("uSideBySide", mCompositeFlags == CompositeFlags::SideBySide);
@@ -946,6 +947,8 @@ void    App::onKeyPressed(const ImGuiIO& io)
         mUseLinearFilter ^= true;
     } else if (ImGui::IsKeyPressed(0x57)) { // w
         mShowPixelMarker ^= true;
+    } else if (ImGui::IsKeyPressed(0x47)) { // g
+        mEnablePixelBorder ^= true;
     } else if (ImGui::IsKeyPressed(0x122)) { // F1
         ImGui::OpenPopup("Home");
     } else if (ImGui::IsKeyPressed(0x126)) { // F5
@@ -1806,6 +1809,7 @@ void    App::initHomeWindow(const char* name)
                 ImGui::Text("Toggle Split View");
                 ImGui::Text("Toggle Side-by-Side Column View");
                 ImGui::Text("Toggle Pixel Warning Markers");
+                ImGui::Text("Toggle Pixel Borders");
                 ImGui::Text("Toggle Linear Image Filter");
                 ImGui::NextColumn();
 
@@ -1814,6 +1818,7 @@ void    App::initHomeWindow(const char* name)
                 ImGui::Text("S");
                 ImGui::Text("C");
                 ImGui::Text("W");
+                ImGui::Text("G");
                 ImGui::Text("Q");
                 ImGui::NextColumn();
                 ImGui::Separator();

--- a/src/app.h
+++ b/src/app.h
@@ -316,6 +316,7 @@ private:
     bool        mUseLinearFilter = true;
     bool        mBlendWithImageAlpha = true;
     bool        mShowImageNameOverlay = true;
+    bool        mEnablePixelBorder = true;
     bool        mShowPixelMarker = false;
     bool        mSupportComputeShader = false;
     bool        mUpdateImageSelection = false;


### PR DESCRIPTION
* The pixel grid can be visually distracting when one isn't interested in actual RGB values. Make it toggleable with keyboard key 'g'.